### PR TITLE
Make breadcrumb path the same as stock Magento

### DIFF
--- a/Jaimin/Breadcrumb/Block/Breadcrumbs.php
+++ b/Jaimin/Breadcrumb/Block/Breadcrumbs.php
@@ -35,22 +35,6 @@ class Breadcrumbs extends MagentoBreadcrumbs
         parent::__construct($context, $data);
     }
 
-    /**
-     * Retrieve HTML title value separator (with space)
-     *
-     * @param null|string|bool|int|Store $store
-     * @return string
-     */
-    public function getTitleSeparator($store = null)
-    {
-        $separator = (string)$this->_scopeConfig->getValue(
-            'catalog/seo/title_separator',
-            ScopeInterface::SCOPE_STORE,
-            $store
-        );
-
-        return ' ' . $separator . ' ';
-    }
 
     public function getCrumbs()
     {
@@ -90,11 +74,6 @@ class Breadcrumbs extends MagentoBreadcrumbs
                     $breadcrumbsBlock->addCrumb("category" . $category->getId(), $catbreadcrumb);
                     $title[] = $category->getName();
                 }
-
-                //add current product to breadcrumb
-                $prodbreadcrumb = ["label" => $product->getName(), "link" => ""];
-                $breadcrumbsBlock->addCrumb("product" . $product->getId(), $prodbreadcrumb);
-                $title[] = $product->getName();
             } else {
                 foreach ($path as $name => $breadcrumb) {
                     $breadcrumbsBlock->addCrumb($name, $breadcrumb);


### PR DESCRIPTION
The stock Magento vendor/magento/magento-catalog/Block/Breadcrumbs.php does not add the current product page to the end of the breadcrumb list. So if a template assumes the standard Magento breadcrumb code it will insert the current page to the end of the breadcrumbs. The way this extension was previously done would mean that the current product page would show up twice in the breadcrumbs. This modification makes the behavior drop-in compatible with the standard Magento breadcrumb code, so it will output in the same way but still have the full breadcrumb path if the page was found via a product search.