### PR TITLE
Fix for deprecated passing null warning in PHP 8.1

### DIFF
--- a/Jaimin/Breadcrumb/Block/Breadcrumbs.php
+++ b/Jaimin/Breadcrumb/Block/Breadcrumbs.php
@@ -80,7 +80,7 @@ class Breadcrumbs extends MagentoBreadcrumbs
                     $title[] = $breadcrumb['label'];
                 }
             }
-            $this->pageConfig->getTitle()->set(join($this->getTitleSeparator(), array_reverse($title)));
+            $this->pageConfig->getTitle()->set(join($this->getTitleSeparator() ?? '', array_reverse($title)));
 
             return parent::_prepareLayout();
         }
@@ -89,7 +89,7 @@ class Breadcrumbs extends MagentoBreadcrumbs
         foreach ($path as $name => $breadcrumb) {
             $title[] = $breadcrumb['label'];
         }
-        $this->pageConfig->getTitle()->set(join($this->getTitleSeparator(), array_reverse($title)));
+        $this->pageConfig->getTitle()->set(join($this->getTitleSeparator() ?? '', array_reverse($title)));
 
         return parent::_prepareLayout();
     }


### PR DESCRIPTION
Fix so that PHP 8.1 no longer gives the deprecation warning "Deprecated Functionality: join(): Passing null to parameter #1 ($separator) of type array|string is deprecated"